### PR TITLE
docs: add comprehensive godoc comments to all packages

### DIFF
--- a/cmd/site2skill/main.go
+++ b/cmd/site2skill/main.go
@@ -1,3 +1,6 @@
+// Package main is the entry point for the site2skill tool.
+// site2skill converts website documentation into Claude/Codex AI skill packages
+// through a multi-step pipeline: fetch, convert, normalize, generate, validate, and package.
 package main
 
 import (
@@ -17,8 +20,10 @@ import (
 )
 
 const (
+	// FormatClaude specifies output format for Claude AI skill packages.
 	FormatClaude = "claude"
-	FormatCodex  = "codex"
+	// FormatCodex specifies output format for OpenAI Codex skill packages.
+	FormatCodex = "codex"
 )
 
 func main() {

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1,3 +1,6 @@
+// Package converter provides HTML to Markdown conversion functionality.
+// It extracts main content from HTML pages, cleans unwanted elements,
+// and converts to Markdown with YAML frontmatter containing metadata.
 package converter
 
 import (
@@ -11,10 +14,12 @@ import (
 	"github.com/JohannesKaufmann/html-to-markdown"
 )
 
+// Converter converts HTML content to Markdown with YAML frontmatter.
 type Converter struct {
 	mdConverter *md.Converter
 }
 
+// New creates a new Converter instance.
 func New() *Converter {
 	converter := md.NewConverter("", true, nil)
 	return &Converter{
@@ -22,6 +27,13 @@ func New() *Converter {
 	}
 }
 
+// ConvertFile converts an HTML file to Markdown with frontmatter.
+// It extracts the main content, removes unwanted elements, and adds YAML frontmatter
+// with the document title, source URL, and fetch timestamp.
+// htmlPath: path to the HTML file to convert
+// outputPath: path where the Markdown file will be written
+// sourceURL: URL where the HTML was fetched from
+// fetchedAt: ISO 3339 timestamp when the page was fetched
 func (c *Converter) ConvertFile(htmlPath, outputPath, sourceURL, fetchedAt string) error {
 	// Read HTML file
 	htmlContent, err := os.ReadFile(htmlPath)

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -1,3 +1,6 @@
+// Package fetcher provides website crawling and downloading functionality.
+// It recursively crawls a website following same-domain links up to a maximum depth,
+// storing HTML files locally while respecting rate limits and skipping non-HTML resources.
 package fetcher
 
 import (
@@ -15,6 +18,7 @@ import (
 	"golang.org/x/net/html"
 )
 
+// Fetcher crawls and downloads website content.
 type Fetcher struct {
 	outputDir     string
 	domain        string
@@ -26,6 +30,7 @@ type Fetcher struct {
 	client        *http.Client
 }
 
+// New creates a new Fetcher instance configured to save downloads to outputDir.
 func New(outputDir string) *Fetcher {
 	return &Fetcher{
 		outputDir: outputDir,
@@ -37,6 +42,10 @@ func New(outputDir string) *Fetcher {
 	}
 }
 
+// Fetch downloads the website starting at targetURL, recursively following
+// same-domain links up to maxDepth. It validates the URL scheme and saves
+// all HTML files to the output directory in a structure preserving the original paths.
+// targetURL must be a valid http or https URL with a domain.
 func (f *Fetcher) Fetch(targetURL string) error {
 	parsedURL, err := url.Parse(targetURL)
 	if err != nil {

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -1,3 +1,6 @@
+// Package normalizer provides Markdown file normalization functionality.
+// It processes YAML frontmatter, resolves relative links to absolute URLs,
+// and reconstructs normalized Markdown files with updated metadata.
 package normalizer
 
 import (
@@ -10,18 +13,29 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Normalizer processes and normalizes Markdown files.
 type Normalizer struct{}
 
+// New creates a new Normalizer instance.
 func New() *Normalizer {
 	return &Normalizer{}
 }
 
+// Frontmatter represents the YAML frontmatter metadata of a Markdown file.
 type Frontmatter struct {
-	Title      string `yaml:"title"`
-	SourceURL  string `yaml:"source_url"`
-	FetchedAt  string `yaml:"fetched_at"`
+	// Title is the document title.
+	Title string `yaml:"title"`
+	// SourceURL is the original URL where the document was fetched from.
+	SourceURL string `yaml:"source_url"`
+	// FetchedAt is the ISO 3339 timestamp when the document was fetched.
+	FetchedAt string `yaml:"fetched_at"`
 }
 
+// NormalizeFile reads a Markdown file, extracts its YAML frontmatter,
+// resolves all relative links to absolute URLs using the source URL,
+// and writes the normalized content to outputPath.
+// inputPath: path to the Markdown file to normalize
+// outputPath: path where the normalized Markdown file will be written
 func (n *Normalizer) NormalizeFile(inputPath, outputPath string) error {
 	content, err := os.ReadFile(inputPath)
 	if err != nil {

--- a/internal/packager/packager.go
+++ b/internal/packager/packager.go
@@ -1,3 +1,6 @@
+// Package packager provides skill packaging functionality.
+// It creates .skill files (ZIP archives) from a skill directory structure,
+// preserving the directory hierarchy and file metadata.
 package packager
 
 import (
@@ -10,12 +13,19 @@ import (
 	"strings"
 )
 
+// Packager creates .skill files from skill directories.
 type Packager struct{}
 
+// New creates a new Packager instance.
 func New() *Packager {
 	return &Packager{}
 }
 
+// Package creates a .skill file (ZIP archive) from the skill directory.
+// It recursively includes all files and directories from skillDir.
+// skillDir: path to the skill directory to package
+// outputDir: directory where the .skill file will be created
+// Returns the path to the created .skill file or an error.
 func (p *Packager) Package(skillDir, outputDir string) (string, error) {
 	// Check if skill directory exists
 	if info, err := os.Stat(skillDir); os.IsNotExist(err) || !info.IsDir() {

--- a/internal/skillgen/skillgen.go
+++ b/internal/skillgen/skillgen.go
@@ -1,3 +1,6 @@
+// Package skillgen provides skill structure generation functionality.
+// It creates skill directory layouts, generates SKILL.md manifests for different AI models,
+// and copies documentation files and search scripts into the skill structure.
 package skillgen
 
 import (
@@ -10,23 +13,34 @@ import (
 )
 
 const (
+	// FormatClaude specifies generation of a Claude-compatible skill.
 	FormatClaude = "claude"
-	FormatCodex  = "codex"
+	// FormatCodex specifies generation of an OpenAI Codex-compatible skill.
+	FormatCodex = "codex"
 )
 
+// templates embeds template files for SKILL.md and search scripts.
 //go:embed templates/*
 var templates embed.FS
 
+// Generator creates skill directory structures.
 type Generator struct {
 	format string
 }
 
+// New creates a new Generator configured for the specified format (claude or codex).
 func New(format string) *Generator {
 	return &Generator{
 		format: format,
 	}
 }
 
+// Generate creates a complete skill directory structure for the specified skill.
+// It creates docs/ and scripts/ directories, generates an appropriate SKILL.md manifest,
+// copies search scripts, and copies markdown documentation files.
+// skillName: name of the skill to generate
+// sourceDir: directory containing Markdown documentation files
+// outputBase: base output directory where the skill directory will be created
 func (g *Generator) Generate(skillName, sourceDir, outputBase string) error {
 	skillDir := filepath.Join(outputBase, skillName)
 	docsDir := filepath.Join(skillDir, "docs")

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,3 +1,6 @@
+// Package validator provides skill validation functionality.
+// It checks skill directory structure, validates required files like SKILL.md,
+// ensures documentation is present, and analyzes skill size against platform limits.
 package validator
 
 import (
@@ -10,12 +13,19 @@ import (
 	"strings"
 )
 
+// Validator validates skill directory structures and content.
 type Validator struct{}
 
+// New creates a new Validator instance.
 func New() *Validator {
 	return &Validator{}
 }
 
+// Validate checks that a skill directory has the required structure and content.
+// It verifies the presence of SKILL.md, docs/ directory with Markdown files,
+// validates YAML frontmatter, and analyzes skill size.
+// skillDir: path to the skill directory to validate
+// Returns true if validation passes, false otherwise.
 func (v *Validator) Validate(skillDir string) bool {
 	log.Printf("Validating skill in: %s", skillDir)
 
@@ -110,8 +120,11 @@ func (v *Validator) Validate(skillDir string) bool {
 	return true
 }
 
+// fileSize represents the size and path of a file.
 type fileSize struct {
+	// size is the file size in bytes.
 	size int64
+	// path is the file path.
 	path string
 }
 


### PR DESCRIPTION
Add package-level documentation comments explaining the purpose and
functionality of each package. Document all exported types, functions,
and methods with parameter descriptions and return value documentation.

- converter: HTML to Markdown conversion with frontmatter
- fetcher: Website crawling with same-domain link following
- normalizer: Markdown normalization and link resolution
- packager: Skill packaging to ZIP archives
- skillgen: Skill structure generation for Claude/Codex
- validator: Skill validation and size analysis
- main: Entry point orchestrating the full pipeline

Follows Go conventions for public API documentation with godoc.