### PR TITLE
Fix: Change all references from laiso to f4ah6o

### DIFF
--- a/cmd/site2skill/main.go
+++ b/cmd/site2skill/main.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/laiso/site2skill/internal/converter"
-	"github.com/laiso/site2skill/internal/fetcher"
-	"github.com/laiso/site2skill/internal/normalizer"
-	"github.com/laiso/site2skill/internal/packager"
-	"github.com/laiso/site2skill/internal/skillgen"
-	"github.com/laiso/site2skill/internal/validator"
+	"github.com/f4ah6o/site2skill/internal/converter"
+	"github.com/f4ah6o/site2skill/internal/fetcher"
+	"github.com/f4ah6o/site2skill/internal/normalizer"
+	"github.com/f4ah6o/site2skill/internal/packager"
+	"github.com/f4ah6o/site2skill/internal/skillgen"
+	"github.com/f4ah6o/site2skill/internal/validator"
 )
 
 const (

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -124,7 +124,7 @@ func (f *Fetcher) crawl(targetURL, crawlDir string, depth int) error {
 	if err != nil {
 		return nil
 	}
-	req.Header.Set("User-Agent", "site2skill/1.0 (+https://github.com/laiso/site2skill)")
+	req.Header.Set("User-Agent", "site2skill/1.0 (+https://github.com/f4ah6o/site2skill)")
 
 	// Be polite: wait 1 second between requests
 	time.Sleep(1 * time.Second)

--- a/site2skill/fetch_site.py
+++ b/site2skill/fetch_site.py
@@ -77,7 +77,7 @@ def fetch_site(url: str, output_dir: str) -> None:
         "--convert-links",
         # Use reject instead of accept to allow extensionless URLs (which are often HTML)
         "--reject=css,js,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,eot,zip,tar,gz,pdf,xml,json,txt",
-        "--user-agent=site2skill/0.1 (+https://github.com/laiso/site2skill)",
+        "--user-agent=site2skill/0.1 (+https://github.com/f4ah6o/site2skill)",
         "--execute", "robots=on", 
         "--wait=1",
         "--random-wait",


### PR DESCRIPTION
Update package imports, User-Agent headers, and copyright notice to reflect that site2skill is now maintained in the f4ah6o repository instead of laiso.

- Update Go module imports in cmd/site2skill/main.go
- Update User-Agent in internal/fetcher/fetcher.go and site2skill/fetch_site.py
- Update copyright in LICENSE