### PR TITLE
feat: Auto-prepend https:// to URLs without scheme

### DIFF
--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -46,7 +46,14 @@ func New(outputDir string) *Fetcher {
 // same-domain links up to maxDepth. It validates the URL scheme and saves
 // all HTML files to the output directory in a structure preserving the original paths.
 // targetURL must be a valid http or https URL with a domain.
+// If the URL scheme is omitted, https:// is automatically prepended.
 func (f *Fetcher) Fetch(targetURL string) error {
+	// Auto-prepend https:// if no scheme is provided
+	if !strings.HasPrefix(targetURL, "http://") && !strings.HasPrefix(targetURL, "https://") {
+		targetURL = "https://" + targetURL
+		log.Printf("No scheme provided, using: %s", targetURL)
+	}
+
 	parsedURL, err := url.Parse(targetURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)


### PR DESCRIPTION
When users provide URLs without a protocol scheme (e.g., "example.com"),
the fetcher now automatically prepends "https://" to the URL.

This change:
- Eliminates "invalid URL scheme" errors for scheme-less URLs
- Defaults to secure HTTPS protocol
- Preserves explicit http:// or https:// if provided
- Logs when auto-prepending occurs for transparency

Fixes the issue where omitting https:// resulted in invalid URL scheme errors.