### PR TITLE
refactor: rename repository to site2skill-go and command to s2s-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN pip install uv
 WORKDIR /workspace
 
 # Copy the entire project
-COPY . /app/site2skill
+COPY . /app/site2skill-go
 
 # Test installation from local path
-RUN uvx --from /app/site2skill site2skill --help
+RUN uvx --from /app/site2skill-go site2skill --help
 
 # Default command shows help
-CMD ["uvx", "--from", "/app/site2skill", "site2skill", "--help"]
+CMD ["uvx", "--from", "/app/site2skill-go", "site2skill", "--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean install test run help
 
 # Binary name
-BINARY_NAME=site2skill
+BINARY_NAME=s2s-go
 BUILD_DIR=bin
 
 # Go parameters
@@ -30,24 +30,24 @@ help:
 build:
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
-	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/site2skill
+	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/s2s-go
 	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
 
 ## build-all: Build for all platforms
 build-all: clean
 	@echo "Building for all platforms..."
 	@mkdir -p $(BUILD_DIR)
-	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/site2skill
-	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/site2skill
-	GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 ./cmd/site2skill
-	GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./cmd/site2skill
-	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd/site2skill
+	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/s2s-go
+	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/s2s-go
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 ./cmd/s2s-go
+	GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./cmd/s2s-go
+	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd/s2s-go
 	@echo "Cross-compilation complete!"
 
 ## install: Install the binary to GOPATH/bin
 install:
 	@echo "Installing $(BINARY_NAME)..."
-	$(GOINSTALL) ./cmd/site2skill
+	$(GOINSTALL) ./cmd/s2s-go
 	@echo "Installation complete!"
 
 ## test: Run tests

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# site2skill
+# site2skill-go
 
 **Turn any documentation website into a Claude or Codex Agent Skill.**
 
-`site2skill` is a tool that scrapes a documentation website, converts it to Markdown, and packages it as an Agent Skill (ZIP format) with proper entry points and search functionality.
+`s2s-go` is a tool that scrapes a documentation website, converts it to Markdown, and packages it as an Agent Skill (ZIP format) with proper entry points and search functionality.
 
 Agent Skills are dynamically loaded knowledge modules that AI assistants use on demand. This tool now supports both:
 - **Claude Agent Skills** - For Claude Code, Claude apps, and the API
@@ -22,7 +22,7 @@ Agent Skills are dynamically loaded knowledge modules that AI assistants use on 
 ### Using `go install` (Recommended)
 
 ```bash
-go install github.com/f4ah6o/site2skill/cmd/site2skill@latest
+go install github.com/f4ah6o/site2skill-go/cmd/s2s-go@latest
 ```
 
 This will download and install the latest version globally. The binary will be placed in `$GOPATH/bin` (usually `~/go/bin`).
@@ -31,19 +31,19 @@ This will download and install the latest version globally. The binary will be p
 
 ```bash
 # Clone the repository
-git clone https://github.com/f4ah6o/site2skill
-cd site2skill
+git clone https://github.com/f4ah6o/site2skill-go
+cd site2skill-go
 
 # Build the binary
-go build -o site2skill ./cmd/site2skill
+go build -o s2s-go ./cmd/s2s-go
 
 # Optional: Install globally
-go install ./cmd/site2skill
+go install ./cmd/s2s-go
 ```
 
 ### Pre-built Binaries
 
-Download the latest release from the [releases page](https://github.com/f4ah6o/site2skill/releases).
+Download the latest release from the [releases page](https://github.com/f4ah6o/site2skill-go/releases).
 
 ## Usage
 
@@ -51,16 +51,16 @@ Download the latest release from the [releases page](https://github.com/f4ah6o/s
 
 ```bash
 # Generate a Claude skill
-site2skill https://docs.example.com myskill
+s2s-go https://docs.example.com myskill
 
 # Generate a Codex skill
-site2skill https://docs.example.com myskill --format codex
+s2s-go https://docs.example.com myskill --format codex
 ```
 
 ### Full Options
 
 ```bash
-site2skill <URL> <SKILL_NAME> [options]
+s2s-go <URL> <SKILL_NAME> [options]
 
 Options:
   -url string
@@ -85,16 +85,16 @@ Options:
 
 ```bash
 # Create a Claude skill for PAY.JP documentation
-site2skill https://docs.pay.jp/v1/ payjp
+s2s-go https://docs.pay.jp/v1/ payjp
 
 # Create a Codex skill for Stripe API
-site2skill https://stripe.com/docs/api stripe --format codex
+s2s-go https://stripe.com/docs/api stripe --format codex
 
 # Custom output directory
-site2skill https://docs.python.org/3/ python3 --output ./my-skills --clean
+s2s-go https://docs.python.org/3/ python3 --output ./my-skills --clean
 
 # Skip fetching (reuse downloaded files)
-site2skill https://docs.example.com example --skip-fetch
+s2s-go https://docs.example.com example --skip-fetch
 ```
 
 ## How it works
@@ -161,9 +161,9 @@ The original Python version is available in the `python-legacy` branch. The Go v
 go test ./...
 
 # Build for all platforms
-GOOS=linux GOARCH=amd64 go build -o site2skill-linux-amd64 ./cmd/site2skill
-GOOS=darwin GOARCH=amd64 go build -o site2skill-darwin-amd64 ./cmd/site2skill
-GOOS=windows GOARCH=amd64 go build -o site2skill-windows-amd64.exe ./cmd/site2skill
+GOOS=linux GOARCH=amd64 go build -o s2s-go-linux-amd64 ./cmd/s2s-go
+GOOS=darwin GOARCH=amd64 go build -o s2s-go-darwin-amd64 ./cmd/s2s-go
+GOOS=windows GOARCH=amd64 go build -o s2s-go-windows-amd64.exe ./cmd/s2s-go
 ```
 
 ## License

--- a/cmd/s2s-go/main.go
+++ b/cmd/s2s-go/main.go
@@ -1,5 +1,5 @@
-// Package main is the entry point for the site2skill tool.
-// site2skill converts website documentation into Claude/Codex AI skill packages
+// Package main is the entry point for the s2s-go tool.
+// s2s-go converts website documentation into Claude/Codex AI skill packages
 // through a multi-step pipeline: fetch, convert, normalize, generate, validate, and package.
 package main
 
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/f4ah6o/site2skill/internal/converter"
-	"github.com/f4ah6o/site2skill/internal/fetcher"
-	"github.com/f4ah6o/site2skill/internal/normalizer"
-	"github.com/f4ah6o/site2skill/internal/packager"
-	"github.com/f4ah6o/site2skill/internal/skillgen"
-	"github.com/f4ah6o/site2skill/internal/validator"
+	"github.com/f4ah6o/site2skill-go/internal/converter"
+	"github.com/f4ah6o/site2skill-go/internal/fetcher"
+	"github.com/f4ah6o/site2skill-go/internal/normalizer"
+	"github.com/f4ah6o/site2skill-go/internal/packager"
+	"github.com/f4ah6o/site2skill-go/internal/skillgen"
+	"github.com/f4ah6o/site2skill-go/internal/validator"
 )
 
 const (
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	if url == "" || skillName == "" {
-		fmt.Fprintf(os.Stderr, "Usage: site2skill <URL> <SKILL_NAME> [options]\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: s2s-go <URL> <SKILL_NAME> [options]\n\n")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/f4ah6o/site2skill
+module github.com/f4ah6o/site2skill-go
 
 go 1.24.7
 

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -135,7 +135,7 @@ func (f *Fetcher) crawl(targetURL, crawlDir string, depth int) error {
 	if err != nil {
 		return nil
 	}
-	req.Header.Set("User-Agent", "site2skill/1.0 (+https://github.com/f4ah6o/site2skill)")
+	req.Header.Set("User-Agent", "s2s-go/1.0 (+https://github.com/f4ah6o/site2skill-go)")
 
 	// Be polite: wait 1 second between requests
 	time.Sleep(1 * time.Second)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "site2skill"
+name = "site2skill-go"
 version = "0.1.0"
 description = "Turn any website into a Claude Skill"
 readme = "README.md"
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.scripts]
-site2skill = "site2skill.main:main"
+s2s-go = "site2skill.main:main"
 
 [tool.setuptools]
 packages = ["site2skill"]

--- a/site2skill/__init__.py
+++ b/site2skill/__init__.py
@@ -1,3 +1,3 @@
-"""site2skill - Turn any website into a Claude Skill"""
+"""site2skill-go - Turn any website into a Claude Skill"""
 
 __version__ = "0.1.0"


### PR DESCRIPTION
- Rename Go module from site2skill to site2skill-go
- Rename command binary from site2skill to s2s-go
- Rename cmd/site2skill directory to cmd/s2s-go
- Update all references in documentation and configuration files
- Update Makefile, Dockerfile, README.md, and pyproject.toml
- Update Go package imports to use site2skill-go module path
- Update User-Agent header to reflect new command name