### PR TITLE
feat: add Codex skills config check warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Download the latest release from the [releases page](https://github.com/f4ah6o/s
 site2skillgo generate https://f4ah6o.github.io/site2skill-go/ myskill
 
 # Generate a Codex skill
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ myskill --format codex
+site2skillgo generate --format codex https://f4ah6o.github.io/site2skill-go/ myskill
 
 # Generate both Claude and Codex skills
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ myskill --format both
+site2skillgo generate --format both https://f4ah6o.github.io/site2skill-go/ myskill
 ```
 
 ### Commands
@@ -98,16 +98,16 @@ site2skillgo search <QUERY> [options]
 site2skillgo generate https://f4ah6o.github.io/site2skill-go/ site2skill
 
 # Create a Codex skill
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ site2skill --format codex
+site2skillgo generate --format codex https://f4ah6o.github.io/site2skill-go/ site2skill
 
 # Create both Claude and Codex skills
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ site2skill --format both
+site2skillgo generate --format both https://f4ah6o.github.io/site2skill-go/ site2skill
 
 # Custom output directory
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ site2skill --output ./my-skills --clean
+site2skillgo generate --output ./my-skills --clean https://f4ah6o.github.io/site2skill-go/ site2skill
 
 # Skip fetching (reuse downloaded files)
-site2skillgo generate https://f4ah6o.github.io/site2skill-go/ site2skill --skip-fetch
+site2skillgo generate --skip-fetch https://f4ah6o.github.io/site2skill-go/ site2skill
 
 # Search in skill documentation
 site2skillgo search "authentication" --skill-dir .claude/skills/site2skill
@@ -151,6 +151,13 @@ Use the built-in `site2skillgo search` command to search through documentation f
 - Plain markdown structure
 - JSON output support
 - Simplified search interface
+
+> **Note**: To use Codex skills, you need to enable the skills feature in `~/.codex/config.toml`:
+> ```toml
+> [features]
+> skills = true
+> ```
+> When generating with `--format codex` or `--format both`, a reminder will be displayed if this setting is missing.
 
 ### Both Format
 - Generates both Claude and Codex skill packages from the same documentation source

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/JohannesKaufmann/html-to-markdown v1.6.0 h1:04VXMiE50YYfCfLboJCLcgqF5x+rHJnb1ssNmqpLH/k=
 github.com/JohannesKaufmann/html-to-markdown v1.6.0/go.mod h1:NUI78lGg/a7vpEJTz/0uOcYMaibytE4BUOQS8k78yPQ=
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=


### PR DESCRIPTION
- Add check for ~/.codex/config.toml [features].skills setting
- Display info message when skills feature is not enabled
- Triggered when using --format codex or --format both
- Add BurntSushi/toml dependency for TOML parsing
- Update README with correct flag ordering and config note