### PR TITLE
docs: add comprehensive godoc documentation

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -123,6 +123,9 @@ fetched_at: "%s"
 	return nil
 }
 
+// cleanHTML removes unwanted elements from the selected HTML content.
+// It eliminates scripts, styles, navigation elements, and other non-content sections
+// to isolate the main documentation content.
 func (c *Converter) cleanHTML(sel *goquery.Selection) {
 	// Remove unwanted elements
 	unwantedSelectors := []string{
@@ -136,6 +139,8 @@ func (c *Converter) cleanHTML(sel *goquery.Selection) {
 	}
 }
 
+// postProcessMarkdown applies final formatting to Markdown content.
+// It removes excessive blank lines and trailing whitespace from each line.
 func (c *Converter) postProcessMarkdown(md string) string {
 	// Remove multiple consecutive blank lines
 	re := regexp.MustCompile(`\n{3,}`)
@@ -150,8 +155,8 @@ func (c *Converter) postProcessMarkdown(md string) string {
 	return strings.Join(lines, "\n")
 }
 
-// decodeHTML decodes HTML bytes to string using detected charset.
-// It tries to extract charset from HTML meta tag.
+// decodeHTML decodes HTML bytes to a string using the detected character encoding.
+// It first attempts to extract the charset from HTML meta tags, then falls back to UTF-8.
 func decodeHTML(body []byte) string {
 	// Try to get charset from HTML meta tag
 	enc := getEncodingFromMeta(body)
@@ -166,8 +171,9 @@ func decodeHTML(body []byte) string {
 	return string(body)
 }
 
-// getEncodingFromMeta extracts charset from HTML meta tag using regex on raw bytes.
-// This avoids parsing the HTML with incorrect encoding which would corrupt the content.
+// getEncodingFromMeta extracts the character encoding from HTML meta tags using regex on raw bytes.
+// This approach avoids parsing HTML with an incorrect encoding, which would corrupt the content.
+// It supports both <meta charset="..."> and <meta http-equiv="Content-Type"> formats.
 func getEncodingFromMeta(body []byte) encoding.Encoding {
 	// Quick check for BOM first
 	if len(body) >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF {
@@ -215,7 +221,7 @@ func getEncodingFromMeta(body []byte) encoding.Encoding {
 	return nil
 }
 
-// decodeWithEncoding decodes bytes using specified encoding.
+// decodeWithEncoding decodes bytes using the specified character encoding.
 func decodeWithEncoding(body []byte, enc encoding.Encoding) (string, error) {
 	reader := transform.NewReader(bytes.NewReader(body), enc.NewDecoder())
 	decoded, err := io.ReadAll(reader)

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -70,6 +70,8 @@ func (n *Normalizer) NormalizeFile(inputPath, outputPath string) error {
 	return nil
 }
 
+// extractFrontmatter parses YAML frontmatter from Markdown content.
+// It extracts the metadata section between --- delimiters and returns the frontmatter struct and remaining body.
 func (n *Normalizer) extractFrontmatter(content string) (*Frontmatter, string, error) {
 	// Match YAML frontmatter
 	re := regexp.MustCompile(`(?s)^---\n(.*?)\n---\n(.*)$`)
@@ -87,6 +89,8 @@ func (n *Normalizer) extractFrontmatter(content string) (*Frontmatter, string, e
 	return &fm, matches[2], nil
 }
 
+// normalizeLinks resolves all relative Markdown links in content to absolute URLs.
+// It uses the sourceURL as the base to resolve relative references and preserves absolute URLs unchanged.
 func (n *Normalizer) normalizeLinks(content, sourceURL string) string {
 	// Regex to capture markdown links: [text](url)
 	re := regexp.MustCompile(`\[([^\]]*)\]\(([^)]+)\)`)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -313,7 +313,7 @@ func FormatJSON(results []SearchResult) error {
 	return encoder.Encode(results)
 }
 
-// min returns the smaller of two integers.
+// min returns the minimum of two integers.
 func min(a, b int) int {
 	if a < b {
 		return a
@@ -321,7 +321,7 @@ func min(a, b int) int {
 	return b
 }
 
-// max returns the larger of two integers.
+// max returns the maximum of two integers.
 func max(a, b int) int {
 	if a > b {
 		return a

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -1,25 +1,43 @@
+// Package search provides types for documentation search operations.
 package search
 
-// SearchResult represents a single search result from a documentation file
+// SearchResult represents a single search result from a documentation file.
+// It includes metadata about where the match was found, how many times it occurred,
+// surrounding context lines, and the source information.
 type SearchResult struct {
-	File      string   `json:"file"`
-	Matches   int      `json:"matches"`
-	Contexts  []string `json:"contexts"`
-	SourceURL string   `json:"source_url"`
-	FetchedAt string   `json:"fetched_at"`
+	// File is the relative path to the documentation file containing the match.
+	File string `json:"file"`
+	// Matches is the total number of keyword matches found in this file.
+	Matches int `json:"matches"`
+	// Contexts is a slice of context snippets, each showing matches with surrounding lines.
+	// Each line is prefixed with "> " for matched lines and "  " for context lines.
+	Contexts []string `json:"contexts"`
+	// SourceURL is the original URL where the documentation was fetched from.
+	SourceURL string `json:"source_url"`
+	// FetchedAt is the ISO 3339 timestamp when the documentation was fetched.
+	FetchedAt string `json:"fetched_at"`
 }
 
-// Frontmatter represents YAML frontmatter from a Markdown file
+// Frontmatter represents YAML frontmatter metadata extracted from a Markdown file.
+// It contains document metadata added during the conversion process.
 type Frontmatter struct {
-	Title     string
+	// Title is the document title from the frontmatter.
+	Title string
+	// SourceURL is the original URL where the document was fetched from.
 	SourceURL string
+	// FetchedAt is the ISO 3339 timestamp when the document was fetched.
 	FetchedAt string
 }
 
-// SearchOptions contains configuration for search operations
+// SearchOptions contains configuration parameters for search operations.
+// It specifies the search scope, query, result limits, and output format.
 type SearchOptions struct {
-	SkillDir   string
-	Query      string
+	// SkillDir is the path to the skill directory containing the docs/ subdirectory to search.
+	SkillDir string
+	// Query is the search query string (space-separated keywords with OR logic).
+	Query string
+	// MaxResults limits the number of results returned (0 means unlimited).
 	MaxResults int
+	// JSONOutput specifies whether to format results as JSON instead of human-readable text.
 	JSONOutput bool
 }

--- a/internal/skillgen/skillgen.go
+++ b/internal/skillgen/skillgen.go
@@ -61,6 +61,8 @@ func (g *Generator) Generate(skillName, sourceDir, outputBase string) error {
 	return nil
 }
 
+// createSkillMD generates the SKILL.md manifest file in the skill directory.
+// The manifest content differs based on the configured format (Claude or Codex).
 func (g *Generator) createSkillMD(skillDir, skillName string) error {
 	skillMDPath := filepath.Join(skillDir, "SKILL.md")
 
@@ -82,6 +84,7 @@ func (g *Generator) createSkillMD(skillDir, skillName string) error {
 	return nil
 }
 
+// getClaudeSkillContent generates the SKILL.md content for Claude-compatible skills.
 func (g *Generator) getClaudeSkillContent(skillName string) string {
 	return fmt.Sprintf(`---
 name: %s
@@ -127,6 +130,7 @@ Options:
 `, skillName, strings.ToUpper(skillName), strings.ToUpper(skillName), strings.ToUpper(skillName))
 }
 
+// getCodexSkillContent generates the SKILL.md content for OpenAI Codex-compatible skills.
 func (g *Generator) getCodexSkillContent(skillName string) string {
 	return fmt.Sprintf(`# %s Documentation Skill
 
@@ -174,6 +178,8 @@ site2skillgo search "payment methods" --json --max-results 5 --skill-dir .
 `, strings.ToUpper(skillName), strings.ToUpper(skillName))
 }
 
+// copyMarkdownFiles copies all Markdown files from the source directory to the docs directory.
+// It performs security checks to prevent directory traversal attacks during the copy process.
 func (g *Generator) copyMarkdownFiles(sourceDir, docsDir string) error {
 	if sourceDir == "" {
 		return fmt.Errorf("source directory is empty")

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -120,14 +120,17 @@ func (v *Validator) Validate(skillDir string) bool {
 	return true
 }
 
-// fileSize represents the size and path of a file.
+// fileSize represents the size and location of a file for analysis.
 type fileSize struct {
 	// size is the file size in bytes.
 	size int64
-	// path is the file path.
+	// path is the absolute file path.
 	path string
 }
 
+// checkSkillSize analyzes the total size of documentation files in the skill.
+// It logs warnings if the skill exceeds Claude's 8MB uncompressed size limit
+// and lists the 10 largest files for debugging purposes.
 func (v *Validator) checkSkillSize(skillDir string) {
 	docsDir := filepath.Join(skillDir, "docs")
 	if _, err := os.Stat(docsDir); os.IsNotExist(err) {


### PR DESCRIPTION
Add or improve godoc comments across the codebase:
- internal/fetcher/locale.go: Translate Japanese comments to English, add function documentation
- internal/search/types.go: Add package comment and field documentation for all struct types
- internal/converter/converter.go: Document helper functions (cleanHTML, postProcessMarkdown, decoding functions)
- internal/fetcher/fetcher.go: Improve SetLocaleConfig and add documentation for internal functions
- internal/normalizer/normalizer.go: Document extractFrontmatter and normalizeLinks helpers
- internal/skillgen/skillgen.go: Document skill generation helper functions
- internal/validator/validator.go: Document size checking and validation helpers
- internal/search/search.go: Minor improvements to min/max function documentation

All public and important private functions now have proper godoc comments following Go conventions.