### PR TITLE
docs(gh-pages): update introduction to highlight dogfooding role

### DIFF
--- a/site/docs/en/pattern-c/index.html
+++ b/site/docs/en/pattern-c/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pattern C: Locale Conflict Test - site2skill-go Documentation</title>
+    <link rel="alternate" hreflang="ja" href="/site2skill-go/docs/ja/pattern-c/">
+    <link rel="alternate" hreflang="en" href="/site2skill-go/docs/en/pattern-c/">
+    <link rel="alternate" hreflang="zh-tw" href="/site2skill-go/docs/zh-tw/pattern-c/">
+    <link rel="canonical" href="/site2skill-go/docs/en/pattern-c/">
+    <style>
+        :root {
+            --bg: #0d1117;
+            --fg: #c9d1d9;
+            --accent: #58a6ff;
+            --border: #30363d;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: var(--accent);
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            color: var(--accent);
+            margin: 2rem 0 1rem;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        code {
+            background: #161b22;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+        }
+
+        pre {
+            background: #161b22;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 1rem 0;
+        }
+
+        a {
+            color: var(--accent);
+        }
+
+        .lang-switcher {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            background: #161b22;
+            border-radius: 8px;
+        }
+
+        .lang-switcher a {
+            margin-right: 1rem;
+        }
+
+        .locale-info {
+            background: #d2992222;
+            border: 1px solid #d29922;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+
+        .conflict-warning {
+            background: #f8514922;
+            border: 1px solid #f85149;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="lang-switcher">🌐 Language: <a href="/site2skill-go/docs/ja/pattern-c/">日本語</a> | <strong>English</strong> | <a href="/site2skill-go/docs/zh-tw/pattern-c/">繁體中文</a></div>
+        <h1>🔀 Pattern C: Locale Conflict Test</h1>
+        <div class="locale-info">
+            <strong>⚠️ Path Locale Priority (Path Locale MUST Win)</strong><br>
+            Path: <code>/docs/en/pattern-c/</code><br>
+            Language Code: <code>en</code><br>
+            Pattern: Mixed Locale Conflict (Pattern C)
+        </div>
+        <div id="conflict-info"></div>
+        <h2>Test Case Description</h2>
+        <p>This page includes a language locale in the path (<code>en</code>) while a query parameter specifies a different language, testing the priority handling.</p>
+        <p><strong>Expected behavior:</strong> The path language (English) should take priority. Query parameters should be ignored.</p>
+        <h2>Conflict Scenarios</h2>
+        <ul>
+            <li><a href="/site2skill-go/docs/en/pattern-c/?lang=ja">English path + Japanese parameter</a></li>
+            <li><a href="/site2skill-go/docs/en/pattern-c/?lang=zh-tw">English path + Traditional Chinese parameter</a></li>
+        </ul>
+        <p><a href="/site2skill-go/">← Back to Home</a></p>
+    </div>
+
+    <script>
+        // Check for query parameter conflict
+        const params = new URLSearchParams(window.location.search);
+        const queryLang = params.get('lang');
+
+        if (queryLang && queryLang !== 'en') {
+            const langMap = {
+                'ja': 'Japanese (日本語)',
+                'zh-tw': 'Traditional Chinese (繁体字中国語)'
+            };
+            const conflictDiv = document.getElementById('conflict-info');
+            conflictDiv.className = 'conflict-warning';
+            conflictDiv.innerHTML = `
+                <strong>⚠️ Locale Conflict Detected</strong><br>
+                Path language: <code>en</code><br>
+                Query parameter language: <code>${queryLang}</code> (${langMap[queryLang] || queryLang})<br>
+                <strong>Path language takes priority. This page is displayed in English.</strong>
+            `;
+        }
+    </script>
+</body>
+
+</html>

--- a/site/docs/ja/pattern-c/index.html
+++ b/site/docs/ja/pattern-c/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>パターンC: ロケール競合テスト - site2skill-go ドキュメント</title>
+    <link rel="alternate" hreflang="ja" href="/site2skill-go/docs/ja/pattern-c/">
+    <link rel="alternate" hreflang="en" href="/site2skill-go/docs/en/pattern-c/">
+    <link rel="alternate" hreflang="zh-tw" href="/site2skill-go/docs/zh-tw/pattern-c/">
+    <link rel="canonical" href="/site2skill-go/docs/ja/pattern-c/">
+    <style>
+        :root {
+            --bg: #0d1117;
+            --fg: #c9d1d9;
+            --accent: #58a6ff;
+            --border: #30363d;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: var(--accent);
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            color: var(--accent);
+            margin: 2rem 0 1rem;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        code {
+            background: #161b22;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+        }
+
+        pre {
+            background: #161b22;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 1rem 0;
+        }
+
+        a {
+            color: var(--accent);
+        }
+
+        .lang-switcher {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            background: #161b22;
+            border-radius: 8px;
+        }
+
+        .lang-switcher a {
+            margin-right: 1rem;
+        }
+
+        .locale-info {
+            background: #d2992222;
+            border: 1px solid #d29922;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+
+        .conflict-warning {
+            background: #f8514922;
+            border: 1px solid #f85149;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="lang-switcher">🌐 言語: <strong>日本語</strong> | <a href="/site2skill-go/docs/en/pattern-c/">English</a> | <a href="/site2skill-go/docs/zh-tw/pattern-c/">繁體中文</a></div>
+        <h1>🔀 パターンC: ロケール競合テスト</h1>
+        <div class="locale-info">
+            <strong>⚠️ パスロケール優先 (Path Locale MUST Win)</strong><br>
+            パス: <code>/docs/ja/pattern-c/</code><br>
+            言語コード: <code>ja</code><br>
+            パターン: Mixed Locale Conflict (Pattern C)
+        </div>
+        <div id="conflict-info"></div>
+        <h2>テストケース説明</h2>
+        <p>このページはパスに言語ロケール（<code>ja</code>）が含まれており、クエリパラメータで異なる言語が指定される場合をテストします。</p>
+        <p><strong>期待する動作:</strong> パスの言語（日本語）が優先されるべきです。クエリパラメータは無視されます。</p>
+        <h2>競合ケース</h2>
+        <ul>
+            <li><a href="/site2skill-go/docs/ja/pattern-c/?lang=en">日本語パス + 英語パラメータ</a></li>
+            <li><a href="/site2skill-go/docs/ja/pattern-c/?lang=zh-tw">日本語パス + 繁体字中国語パラメータ</a></li>
+        </ul>
+        <p><a href="/site2skill-go/">← トップページへ戻る</a></p>
+    </div>
+
+    <script>
+        // Check for query parameter conflict
+        const params = new URLSearchParams(window.location.search);
+        const queryLang = params.get('lang');
+
+        if (queryLang && queryLang !== 'ja') {
+            const langMap = {
+                'en': 'English (英語)',
+                'zh-tw': 'Traditional Chinese (繁体字中国語)'
+            };
+            const conflictDiv = document.getElementById('conflict-info');
+            conflictDiv.className = 'conflict-warning';
+            conflictDiv.innerHTML = `
+                <strong>⚠️ ロケール競合が検出されました</strong><br>
+                パス言語: <code>ja</code><br>
+                クエリパラメータ言語: <code>${queryLang}</code> (${langMap[queryLang] || queryLang})<br>
+                <strong>パス言語が優先されます。このページは日本語で表示されています。</strong>
+            `;
+        }
+    </script>
+</body>
+
+</html>

--- a/site/docs/pattern-b/index.html
+++ b/site/docs/pattern-b/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pattern B: Query-based Locale - site2skill-go Documentation</title>
+    <link rel="alternate" hreflang="ja" href="/site2skill-go/docs/pattern-b/?lang=ja">
+    <link rel="alternate" hreflang="en" href="/site2skill-go/docs/pattern-b/?lang=en">
+    <link rel="alternate" hreflang="zh-tw" href="/site2skill-go/docs/pattern-b/?lang=zh-tw">
+    <style>
+        :root {
+            --bg: #0d1117;
+            --fg: #c9d1d9;
+            --accent: #58a6ff;
+            --border: #30363d;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: var(--accent);
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            color: var(--accent);
+            margin: 2rem 0 1rem;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        code {
+            background: #161b22;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+        }
+
+        pre {
+            background: #161b22;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 1rem 0;
+        }
+
+        a {
+            color: var(--accent);
+        }
+
+        .lang-switcher {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            background: #161b22;
+            border-radius: 8px;
+        }
+
+        .lang-switcher a {
+            margin-right: 1rem;
+        }
+
+        .locale-info {
+            background: #2ea04322;
+            border: 1px solid #2ea043;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="lang-switcher">🌐 <span id="lang-label">Language:</span>
+            <a href="/site2skill-go/docs/pattern-b/?lang=ja">日本語</a> |
+            <a href="/site2skill-go/docs/pattern-b/?lang=en">English</a> |
+            <a href="/site2skill-go/docs/pattern-b/?lang=zh-tw">繁體中文</a>
+        </div>
+        <h1 id="title">Query Parameter Locale</h1>
+        <div class="locale-info">
+            <strong id="info-label">Locale Info:</strong><br>
+            <span id="path-info">Path: <code>/docs/pattern-b/</code></span><br>
+            <span id="query-info">Query Parameter: <code id="query-param">lang=en</code></span><br>
+            <span id="pattern-info">Pattern: Query-based locale (Pattern B)</span>
+        </div>
+        <h2 id="content-title">Content Title</h2>
+        <p id="content-desc">Content description</p>
+        <p><a href="/site2skill-go/">← <span id="back-link">Back to Home</span></a></p>
+    </div>
+
+    <script>
+        // Get language from query parameter, default to 'en'
+        const params = new URLSearchParams(window.location.search);
+        const lang = params.get('lang') || 'en';
+
+        // Define translations
+        const translations = {
+            en: {
+                'lang-label': 'Language:',
+                'title': '🚀 Query Parameter Locale Test',
+                'info-label': 'Locale Info:',
+                'path-info': 'Path: <code>/docs/pattern-b/</code>',
+                'query-param': `lang=${lang}`,
+                'pattern-info': 'Pattern: Query-based locale (Pattern B)',
+                'content-title': 'What is site2skill-go?',
+                'content-desc': '<code>site2skill-go</code> is a tool that crawls documentation websites and converts them into skill packages for Claude and Codex agents.',
+                'back-link': 'Back to Home'
+            },
+            ja: {
+                'lang-label': '言語:',
+                'title': '🚀 クエリパラメータロケールテスト',
+                'info-label': 'ロケール情報:',
+                'path-info': 'パス: <code>/docs/pattern-b/</code>',
+                'query-param': `lang=${lang}`,
+                'pattern-info': 'パターン: Query-based locale (Pattern B)',
+                'content-title': 'site2skill-go とは？',
+                'content-desc': '<code>site2skill-go</code> は、ドキュメントウェブサイトをクロールし、Claude や Codex エージェント用のスキルパッケージに変換するツールです。',
+                'back-link': 'トップページへ戻る'
+            },
+            'zh-tw': {
+                'lang-label': '語言:',
+                'title': '🚀 查詢參數地區設定測試',
+                'info-label': '地區設定資訊:',
+                'path-info': '路徑: <code>/docs/pattern-b/</code>',
+                'query-param': `lang=${lang}`,
+                'pattern-info': '模式: 查詢參數地區設定 (Pattern B)',
+                'content-title': '什麼是 site2skill-go？',
+                'content-desc': '<code>site2skill-go</code> 是一個爬取文件網站的工具，可將其轉換為 Claude 和 Codex 代理的技能包。',
+                'back-link': '返回首頁'
+            }
+        };
+
+        // Validate language
+        if (!translations[lang]) {
+            window.location.search = '?lang=en';
+        }
+
+        // Apply translations
+        const t = translations[lang];
+        document.documentElement.lang = lang;
+        document.querySelector('title').textContent = `Pattern B: ${t['title']} - site2skill-go`;
+
+        document.getElementById('lang-label').textContent = t['lang-label'];
+        document.getElementById('title').textContent = t['title'];
+        document.getElementById('info-label').textContent = t['info-label'];
+        document.getElementById('path-info').innerHTML = t['path-info'];
+        document.getElementById('query-param').textContent = t['query-param'];
+        document.getElementById('pattern-info').textContent = t['pattern-info'];
+        document.getElementById('content-title').textContent = t['content-title'];
+        document.getElementById('content-desc').innerHTML = t['content-desc'];
+        document.getElementById('back-link').textContent = t['back-link'];
+    </script>
+</body>
+
+</html>

--- a/site/docs/zh-tw/pattern-c/index.html
+++ b/site/docs/zh-tw/pattern-c/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>模式C: 地區設定衝突測試 - site2skill-go 文件</title>
+    <link rel="alternate" hreflang="ja" href="/site2skill-go/docs/ja/pattern-c/">
+    <link rel="alternate" hreflang="en" href="/site2skill-go/docs/en/pattern-c/">
+    <link rel="alternate" hreflang="zh-tw" href="/site2skill-go/docs/zh-tw/pattern-c/">
+    <link rel="canonical" href="/site2skill-go/docs/zh-tw/pattern-c/">
+    <style>
+        :root {
+            --bg: #0d1117;
+            --fg: #c9d1d9;
+            --accent: #58a6ff;
+            --border: #30363d;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: var(--accent);
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            color: var(--accent);
+            margin: 2rem 0 1rem;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        code {
+            background: #161b22;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+        }
+
+        pre {
+            background: #161b22;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 1rem 0;
+        }
+
+        a {
+            color: var(--accent);
+        }
+
+        .lang-switcher {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            background: #161b22;
+            border-radius: 8px;
+        }
+
+        .lang-switcher a {
+            margin-right: 1rem;
+        }
+
+        .locale-info {
+            background: #d2992222;
+            border: 1px solid #d29922;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+
+        .conflict-warning {
+            background: #f8514922;
+            border: 1px solid #f85149;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="lang-switcher">🌐 語言: <a href="/site2skill-go/docs/ja/pattern-c/">日本語</a> | <a href="/site2skill-go/docs/en/pattern-c/">English</a> | <strong>繁體中文</strong></div>
+        <h1>🔀 模式C: 地區設定衝突測試</h1>
+        <div class="locale-info">
+            <strong>⚠️ 路徑地區設定優先 (Path Locale MUST Win)</strong><br>
+            路徑: <code>/docs/zh-tw/pattern-c/</code><br>
+            語言代碼: <code>zh-tw</code><br>
+            模式: 混合地區設定衝突 (Pattern C)
+        </div>
+        <div id="conflict-info"></div>
+        <h2>測試案例說明</h2>
+        <p>此頁面在路徑中包含語言地區設定（<code>zh-tw</code>），同時查詢參數指定不同的語言，以測試優先級處理。</p>
+        <p><strong>預期行為:</strong> 路徑語言（繁體中文）應優先。查詢參數應被忽略。</p>
+        <h2>衝突情景</h2>
+        <ul>
+            <li><a href="/site2skill-go/docs/zh-tw/pattern-c/?lang=ja">繁體中文路徑 + 日文參數</a></li>
+            <li><a href="/site2skill-go/docs/zh-tw/pattern-c/?lang=en">繁體中文路徑 + 英文參數</a></li>
+        </ul>
+        <p><a href="/site2skill-go/">← 返回首頁</a></p>
+    </div>
+
+    <script>
+        // Check for query parameter conflict
+        const params = new URLSearchParams(window.location.search);
+        const queryLang = params.get('lang');
+
+        if (queryLang && queryLang !== 'zh-tw') {
+            const langMap = {
+                'ja': 'Japanese (日本語)',
+                'en': 'English (英語)'
+            };
+            const conflictDiv = document.getElementById('conflict-info');
+            conflictDiv.className = 'conflict-warning';
+            conflictDiv.innerHTML = `
+                <strong>⚠️ 檢測到地區設定衝突</strong><br>
+                路徑語言: <code>zh-tw</code><br>
+                查詢參數語言: <code>${queryLang}</code> (${langMap[queryLang] || queryLang})<br>
+                <strong>路徑語言優先。此頁面以繁體中文顯示。</strong>
+            `;
+        }
+    </script>
+</body>
+
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -150,16 +150,19 @@
 
         <h3>Pattern B: Query-based Locale</h3>
         <ul>
-            <li><a href="/site2skill-go/docs/getting-started/?lang=ja">/docs/getting-started/?lang=ja</a></li>
-            <li><a href="/site2skill-go/docs/getting-started/?lang=en">/docs/getting-started/?lang=en</a></li>
+            <li><a href="/site2skill-go/docs/pattern-b/?lang=ja">/docs/pattern-b/?lang=ja</a> - Japanese</li>
+            <li><a href="/site2skill-go/docs/pattern-b/?lang=en">/docs/pattern-b/?lang=en</a> - English</li>
+            <li><a href="/site2skill-go/docs/pattern-b/?lang=zh-tw">/docs/pattern-b/?lang=zh-tw</a> - Traditional Chinese</li>
         </ul>
-        <p>Path is identical. Locale is specified via query parameter.</p>
+        <p>Path is identical. Locale is specified via query parameter. Single page with JavaScript-based locale switching.</p>
 
         <h3>Pattern C: Mixed Locale (Conflict)</h3>
         <ul>
-            <li><a href="/site2skill-go/docs/ja/getting-started/?lang=en">/docs/ja/getting-started/?lang=en</a></li>
+            <li><a href="/site2skill-go/docs/ja/pattern-c/?lang=en">/docs/ja/pattern-c/?lang=en</a> - Japanese path + English query</li>
+            <li><a href="/site2skill-go/docs/en/pattern-c/?lang=ja">/docs/en/pattern-c/?lang=ja</a> - English path + Japanese query</li>
+            <li><a href="/site2skill-go/docs/zh-tw/pattern-c/?lang=en">/docs/zh-tw/pattern-c/?lang=en</a> - Traditional Chinese path + English query</li>
         </ul>
-        <p>Path locale and query locale conflict. Path locale MUST win.</p>
+        <p>Path locale and query locale conflict. Path locale MUST win. Each page detects and displays the conflict.</p>
 
         <h3>Pattern D: No Locale</h3>
         <ul>
@@ -210,15 +213,19 @@ Disallow:</code></pre>
                     <td><span class="badge badge-success">Only en is fetched</span></td>
                 </tr>
                 <tr>
-                    <td>query-only locale</td>
-                    <td><span class="badge badge-warning">Treated as locale hint</span></td>
+                    <td>Pattern B: query-only locale</td>
+                    <td><span class="badge badge-warning">Treated as locale hint, dynamically rendered</span></td>
+                </tr>
+                <tr>
+                    <td>Pattern C: path + query conflict</td>
+                    <td><span class="badge badge-success">Path locale takes priority, query ignored</span></td>
                 </tr>
                 <tr>
                     <td>robots disallow</td>
                     <td><span class="badge badge-danger">Must not be fetched</span></td>
                 </tr>
                 <tr>
-                    <td>mixed locale</td>
+                    <td>mixed locale conflict</td>
                     <td><span class="badge badge-success">Path locale wins</span></td>
                 </tr>
             </tbody>


### PR DESCRIPTION
Updated the site introduction to reflect that the GitHub Pages site
serves as a dogfooding ground for site2skill-go, verifying crawler
behavior with real-world complexity and URL pattern ambiguity.