### PR TITLE
docs: remove Pre-built Binaries section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ go build -o site2skillgo ./cmd/site2skillgo
 go install ./cmd/site2skillgo
 ```
 
-### Pre-built Binaries
-
-Download the latest release from the [releases page](https://github.com/f4ah6o/site2skill-go/releases).
-
 ## Usage
 
 ### Basic Usage


### PR DESCRIPTION
Pre-built binaries are not being provided, so the section has been removed.