### PR TITLE
Handle converter outputs without parent directories

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -41,14 +42,14 @@ func New() *Converter {
 
 // ConvertFile converts an HTML file to Markdown with YAML frontmatter metadata.
 // It performs the following steps:
-//   1. Reads and decodes the HTML file with proper charset handling
-//   2. Parses the HTML and extracts the title (from <title> or <h1>)
-//   3. Identifies and extracts main content (from <main>, <article>, <div.content>, or <body>)
-//   4. Removes unwanted elements (scripts, styles, navigation, etc.)
-//   5. Converts cleaned HTML to Markdown
-//   6. Post-processes Markdown (removes excess whitespace)
-//   7. Adds YAML frontmatter with title, source URL, and fetch timestamp
-//   8. Writes the final Markdown to the output file
+//  1. Reads and decodes the HTML file with proper charset handling
+//  2. Parses the HTML and extracts the title (from <title> or <h1>)
+//  3. Identifies and extracts main content (from <main>, <article>, <div.content>, or <body>)
+//  4. Removes unwanted elements (scripts, styles, navigation, etc.)
+//  5. Converts cleaned HTML to Markdown
+//  6. Post-processes Markdown (removes excess whitespace)
+//  7. Adds YAML frontmatter with title, source URL, and fetch timestamp
+//  8. Writes the final Markdown to the output file
 //
 // Parameters:
 //   - htmlPath: Path to the HTML file to convert
@@ -128,9 +129,12 @@ fetched_at: "%s"
 
 	finalMD := frontmatter + markdown
 
-	// Ensure output directory exists
-	if err := os.MkdirAll(strings.TrimSuffix(outputPath, "/"+strings.Split(outputPath, "/")[len(strings.Split(outputPath, "/"))-1]), 0755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
+	// Ensure output directory exists when one is specified
+	outputDir := filepath.Dir(outputPath)
+	if outputDir != "" && outputDir != "." {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
 	}
 
 	// Write output

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -34,5 +36,38 @@ func TestPostProcessMarkdown(t *testing.T) {
 				t.Errorf("postProcessMarkdown() returned empty for non-empty input")
 			}
 		})
+	}
+}
+
+func TestConvertFileCreatesOutputInCurrentDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	htmlPath := filepath.Join(tmpDir, "input.html")
+	html := `<html><body><main><h1>Title</h1><p>Hello</p></main></body></html>`
+
+	if err := os.WriteFile(htmlPath, []byte(html), 0644); err != nil {
+		t.Fatalf("failed to write html fixture: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change working directory: %v", err)
+	}
+
+	c := New()
+	outputPath := "output.md"
+
+	if err := c.ConvertFile(htmlPath, outputPath, "https://example.com/docs", "2024-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("ConvertFile returned error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, outputPath)); err != nil {
+		t.Fatalf("expected output file to be created, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure ConvertFile only creates parent directories when needed so outputs in the current working directory no longer fail
- add a regression test covering ConvertFile writing to a relative output path

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b595b3388326b6dc3f8ca0e3d657)